### PR TITLE
pass the new position along in the resize callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Calls back with (`direction: string`, `styleSize: object`, `clientSize: object`,
 #### `onResize: PropTypes.func`
 
 Calls when resizable component resize.
-Calls back with (`direction: string`, `styleSize: object`, `clientSize: object`, `delta: object`)
+Calls back with (`direction: string`, `styleSize: object`, `clientSize: object`, `delta: object`, `newPos: object`)
 
 - direction: `top`, `right`, `bottom`, `left`, `topRight`, `bottomRight`, `bottomLeft`, and `topLeft`.
 - styleSize: `{ width, height }`
@@ -155,6 +155,8 @@ Calls back with (`direction: string`, `styleSize: object`, `clientSize: object`,
   - this argument is `clientWidth` and `clientHeight`.
 - delta: `{ width, height }`
   - this delta width and height by resize. 
+- newPos: `{ width, height }`
+  - new position of the element.
   
 For example, when `<Resizable width={100} height={200} style={{ padding: '20px'}} onResize={...} />` mounted and resize 'right' 20px, this callback is called with `('right', { width: 120, height: 200 }, { width: 160, height: 240 }, {width: 20, height: 0})`
   

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Calls back with (`direction: string`, `styleSize: object`, `clientSize: object`,
   - this argument is `clientWidth` and `clientHeight`.
 - delta: `{ width, height }`
   - this delta width and height by resize. 
-- newPos: `{ width, height }`
+- newPos: `{ x, y }`
   - new position of the element.
   
 For example, when `<Resizable width={100} height={200} style={{ padding: '20px'}} onResize={...} />` mounted and resize 'right' 20px, this callback is called with `('right', { width: 120, height: 200 }, { width: 160, height: 240 }, {width: 20, height: 0})`

--- a/src/index.js
+++ b/src/index.js
@@ -141,7 +141,10 @@ export default class ReactRnd extends Component {
     if (/top/i.test(dir)) {
       this.setState({ y: this.state.original.y - delta.height });
     }
-    this.props.onResize(dir, styleSize, clientSize, delta);
+    this.props.onResize(dir, styleSize, clientSize, delta, {
+        x: this.state.x,
+        y: this.state.y
+    });
   }
 
   onResizeStop(dir, styleSize, clientSize, delta) {


### PR DESCRIPTION
When an element is resized to the left or to the top not only the size of the element changes, but also the position. Currently if something is resized to the left it's rather hard to figure out this new position, so why not just pass it along in the onResize() callback?

(code is untested)