### PR TITLE
Do not mutate boxStyle variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -213,7 +213,7 @@ export default class ReactRnd extends Component {
         x={x}
         y={y}
       >
-        <div style={Object.assign(boxStyle, { zIndex })}>
+        <div style={Object.assign({}, boxStyle, { zIndex })}>
           <Resizable
             ref={c => { this.resizable = c; }}
             onClick={onClick}


### PR DESCRIPTION
I am using `react-rnd` with two overlapping components and I have come across the same problem as described [in this issue](https://github.com/bokuweb/react-rnd/issues/80). Problem is with the `Object.assign` call, which mutates the original variable (which is shared between all component instances).