### PR TITLE
Add extendsProps

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -349,6 +349,7 @@ export default class Rnd extends Component {
           className={this.props.className}
           style={innerStyle}
           ref={(c: HTMLElement) => { this.wrapper = c; }}
+          {...this.props.extendsProps}
         >
           <Resizable
             ref={(c: Resizable) => { this.resizable = c; }}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

[extendsProps](https://github.com/bokuweb/react-rnd#extendsprops-any) is mentioned in the README but has not been added to the render method yet.

An example of the usage is that I need to display resize handlers (like dashed borders) only when the RND is `:focus`d, then I should set an extra `tabIndex` property to the RND by setting the `extendsProps`

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->

The extendsProps is added to the inner div but not the outer Draggable because the react-draggable dose not provide extra props injection (at least as the current document says).

### Testing Done
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


