### PR TITLE
Allow SSR initial rendering without waiting parent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ export default class Rnd extends React.Component<Props, State> {
     onResizeStop: () => {},
     onDragStart: () => {},
     onDrag: () => {},
-    onDragStop: () => {},
+    onDragStop: () => {}
   };
   resizable: React$ElementRef<typeof Resizable> | null;
   draggable: Draggable;
@@ -423,8 +423,8 @@ export default class Rnd extends React.Component<Props, State> {
       ...cursorStyle,
       ...this.props.style,
     };
-    // HACK: Wait for setting relative to parent element.
-    if (!this.state.isMounted) return <div />;
+    // HACK: Wait for setting relative to parent element, if props.absolutePos was not set ( SSR need initial render ). 
+    if (!this.state.isMounted && !this.props.hasOwnProperty("absolutePos")) return <div />;
     const maxHeight = this.props._freeBottomBounds ? 2147483647 : this.state.maxHeight; // eslint-disable-line
     return (
       <Draggable


### PR DESCRIPTION
Problem : no SSR initial render as the comp wait his parent 

### Proposed solution
Add a flag 'absolutePos' in props so the rnd comp render without waiting the parent node

### Tradeoffs
no tradeoff, optional for absolute & ssr rendering


### Testing Done
have tested it


https://github.com/CaipiLabs/rescope-samples/tree/master/src/minimal-ssr