### PR TITLE
Fixes 451

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -488,7 +488,7 @@ export class Rnd extends React.Component<Props, State> {
     // Remove unknown props, see also https://reactjs.org/warnings/unknown-prop.html
     delete resizableProps.default;
 
-    const cursorStyle = disableDragging || dragHandleClassName ? { cursor: "normal" } : { cursor: "move" };
+    const cursorStyle = disableDragging || dragHandleClassName ? { cursor: "auto" } : { cursor: "move" };
     const innerStyle = {
       ...resizableStyle,
       ...cursorStyle,


### PR DESCRIPTION
This PR fixes https://github.com/bokuweb/react-rnd/issues/451

### Proposed solution
`normal` is an invalid value for `cursor`. This PR uses `auto`, which is the default CSS value.

### Tradeoffs
`cursor:normal` was never set as an actual style value by react in the DOM. Now, I wonder if people started setting up their custom overrides in the CSS, if so, this patch is going to break them.
An alternative would be setting the value to `null`, however, this would not be as clean and harder to explain to who reads the code.

### Testing Done
Tested by creating a local version of https://codesandbox.io/s/73n5rmwq51


