### PR TITLE
Fix #526 : controlled component without onResize left/top wrong sizing 

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -443,11 +443,18 @@ export class Rnd extends React.Component<Props, State> {
     let x;
     let y;
     const offset = this.getOffsetFromParent();
+    const isOnResizeCallbackDefined = this.props.onResize !== Rnd.defaultProps.onResize;
+    const width = this.resizable.state.original.width + delta.width;
+    const height = this.resizable.state.original.height + delta.height;
     if (/left/i.test(direction)) {
       x = this.state.original.x - delta.width;
       // INFO: If uncontrolled component, apply x position by resize to draggable.
       if (!this.props.position) {
         this.draggable.setState({ x });
+      }
+      if (!isOnResizeCallbackDefined) {
+        this.draggable.setState({ x });
+        this.resizable.updateSize({ width, height });
       }
       x += offset.left;
     }
@@ -456,6 +463,10 @@ export class Rnd extends React.Component<Props, State> {
       // INFO: If uncontrolled component, apply y position by resize to draggable.
       if (!this.props.position) {
         this.draggable.setState({ y });
+      }
+      if (!isOnResizeCallbackDefined) {
+        this.draggable.setState({ y });
+        this.resizable.updateSize({ width, height });
       }
       y += offset.top;
     }
@@ -558,7 +569,8 @@ export class Rnd extends React.Component<Props, State> {
     };
     const { left, top } = this.getOffsetFromParent();
     let draggablePosition;
-    if (position) {
+    const isOnResizeCallbackDefined = this.props.onResize !== Rnd.defaultProps.onResize;
+    if (position && isOnResizeCallbackDefined) {
       draggablePosition = {
         x: position.x - left,
         y: position.y - top,

--- a/stories/basic/controlledOnStop.tsx
+++ b/stories/basic/controlledOnStop.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { Rnd } from "../../src";
+import { style } from "../styles";
+
+type State = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export default class Example extends React.Component<{}, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+    };
+  }
+
+  render() {
+    return (
+      <Rnd
+        style={style}
+        size={{
+          width: this.state.width,
+          height: this.state.height,
+        }}
+        position={{
+          x: this.state.x,
+          y: this.state.y,
+        }}
+        onDragStop={(e, d) => {
+          this.setState({ x: d.x, y: d.y });
+        }}
+        onResizeStop={(e, direction, ref, delta, position) => {
+          this.setState({
+            width: ref.offsetWidth,
+            height: ref.offsetHeight,
+            ...position
+          });
+        }}
+      >
+        001
+      </Rnd>
+    );
+  }
+}

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -6,6 +6,7 @@ import Bare from "./bare/bare";
 
 import BasicUncontrolled from "./basic/uncontrolled";
 import BasicControlled from "./basic/controlled";
+import BasicControlledOnStop from "./basic/controlledOnStop";
 
 import ScaleParentUnControlled from "./scale/parent-uncontrolled";
 import ScaleWindowUnControlled from "./scale/window-uncontrolled";
@@ -45,6 +46,7 @@ storiesOf("bare", module).add("bare", () => <Bare />);
 storiesOf("basic", module)
   .add("uncontrolled", () => <BasicUncontrolled />)
   .add("controlled", () => <BasicControlled />)
+  .add("controlled on stop", () => <BasicControlledOnStop />)
   .add("multi uncontrolled", () => <BasicMultiUncontrolled />)
   .add("multi controlled", () => <BasicMultiControlled />);
 
@@ -64,7 +66,6 @@ storiesOf("scale", module)
   .add("with selector boundary uncontrolled", () => <ScaleSelectorUnControlled />)
   .add("with selector boundary controlled", () => <ScaleSelectorControlled />)
   .add("with selector boundary", () => <ScaleSelectorUnControlled />);
-
 
 storiesOf("size", module)
   .add("percent uncontrolled", () => <SizePercentUncontrolled />)


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Fixes: #526 
When using controlled component without `onResize` callback left\top\leftTop resize changes opposite coordinate

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
It possibly can cause performance degradation because handling the lack of `onResize` prop added in `render` and `onResize` methods

### Testing Done
<!-- How have you confirmed this feature works? -->
I added basic/controlled on stop story for testing

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


