### PR TITLE
Made setting environment variable in test script compatible with multiple environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:prod:main": "rollup -c scripts/prod.js",
     "build:prod:es5": "rollup -c scripts/prod.es5.js",
     "build": "npm-run-all --serial build:prod:* copy:flow",
-    "test": "NODE_ENV='test' tsc && avaron lib/index.test.js --renderer",
+    "test": "cross-env NODE_ENV='test' tsc && avaron lib/index.test.js --renderer",
     "copy:flow": "cpy src/index.js.flow lib && cpy src/index.js.flow lib --rename index.es5.js.flow",
     "test:ci": "npm run flow && npm run build",
     "prepublish": "npm run build",
@@ -89,7 +89,8 @@
     "tslint-eslint-rules": "5.4.0",
     "tslint-plugin-prettier": "2.0.1",
     "tslint-react": "4.0.0",
-    "typescript": "3.5.3"
+    "typescript": "3.5.3",
+    "cross-env" : "5.2.0"
   },
   "files": [
     "lib"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4162,6 +4162,14 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+cross-env@5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -6506,7 +6514,7 @@ is-utf8@^0.2.0, is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
-is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 


### PR DESCRIPTION
### Proposed solution

Use cross_env library to handle setting environment variable for test script.

Previously it only worked probably on linux only-systems. It had
command `NODE_ENV='test'` which did not work under Windows.


<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs

There will be new dependency for the package which has [no vulnerabilities](https://snyk.io/vuln/npm:cross-env).


### Testing Done
I run `yarn run test` on Debian and on Windows 10 and it passed all 33 tests.

