### PR TITLE
Fixing #641

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
 import * as React from "react";
-import { DraggableEventHandler } from "react-draggable";
+import { DraggableEventHandler, default as DraggableRoot } from "react-draggable";
 import { Resizable, ResizeDirection } from "re-resizable";
 
 // FIXME: https://github.com/mzabriskie/react-draggable/issues/381
 //         I can not find `scale` too...
 type $TODO = any;
-const Draggable = require("react-draggable");
+const Draggable: any = DraggableRoot;
 
 export type Grid = [number, number];
 
@@ -589,6 +589,7 @@ export class Rnd extends React.PureComponent<Props, State> {
     }
     // INFO: Make uncontorolled component when resizing to control position by setPostion.
     const pos = this.resizing ? undefined : draggablePosition;
+
     return (
       <Draggable
         ref={this.refDraggable}


### PR DESCRIPTION
### Proposed solution
The fixes #641 without causing other issues with typing.

The original code used method below to solve type issues:

```js
const Draggable = require('react-draggable'); // type is any
```

The drawback with this approach is that rollup has a difficult time bundling react-draggable (as mentioned in the issue). Using an ESM and aliasing the import:

1. Solves the UMD bundling issue
2. Ensures types don't break

```js
import { default as DraggableRoot } from 'react-draggable';

const Draggable: any = DraggableRoot;
```

### Trade-offs

This is the least-invasive solution and the one that is least likely to cause issues. Eventually it would be nice to fix the typescript issues properly, but that will take time and might require some PRs to `react-draggable`.

### Testing Done

* Unit tests pass
* Storybook loads
* Type checking passes without errors