### PR TITLE
fixed propagtation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -346,7 +346,7 @@ export class Rnd extends React.PureComponent<Props, State> {
   onDrag(e: RndDragEvent, data: DraggableData) {
     if (this.props.onDrag) {
       const offset = this.offsetFromParent;
-      this.props.onDrag(e, { ...data, x: data.x - offset.left, y: data.y - offset.top });
+      return this.props.onDrag(e, { ...data, x: data.x - offset.left, y: data.y - offset.top });
     }
   }
 


### PR DESCRIPTION
A minor fix for a bug with forwarding of cancelling indication of an `onDrag` event from `react-rnd` to `react draggable` for uncontrolled handling of the coordinates