### PR TITLE
Fix #707: passing nodeRef prop causes dragging to become jittery

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,26 +498,6 @@ class YourComponent extends Component {
 
 If set to `true`, will allow dragging on non left-button clicks.
 
-#### `nodeRef?: React.Ref<typeof React.Component>`
-
-please see, https://github.com/STRML/react-draggable
-```
-If running in React Strict mode, ReactDOM.findDOMNode() is deprecated.
-Unfortunately, in order for <Draggable> to work properly, we need raw access
-to the underlying DOM node. If you want to avoid the warning, pass a `nodeRef`
-as in this example:
-
-function MyComponent() {
-   const nodeRef = React.useRef(null);
-   return (
-     <Rnd nodeRef={nodeRef}>
-       <div ref={nodeRef}>Example Target</div>
-     </Rnd>
-   );
-}
-
-```
-
 ## Test
 
 ``` sh

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -626,7 +626,7 @@ export class Rnd extends React.PureComponent<Props, State> {
         cancel={cancel}
         scale={scale}
         allowAnyClick={allowAnyClick}
-        nodeRef={nodeRef}
+        nodeRef={{ current: this.getSelfElement() }}
       >
         <Resizable
           {...resizableProps}


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution

Fixes new issue related to #707 

In strict mode, react warns that React-Draggable's usage of `ReactDOM.findDOMNode()` is deprecated. Passing the `nodeRef` prop to `<Rnd />` silences the error, but causes dragging to become jittery. This is because React-Draggable expects the `nodeRef` to reference its top level child, which is actually the `<div>` rendered by re-resizable.

Instead of allowing a `nodeRef` to be passed to react-rnd, we can pass the resizable ref using `Rnd.prototype.getSelfElement()`. Since React-Draggable expects a ref object, it is passed as the `current` value of an object like this:

This PR also removes documentation from the react-rnd `README.md` that references allowing users to pass `nodeRef`.

```jsx
<Draggable
  ...
  nodeRef={{ current: this.getSelfElement() }}
>
```

### Tradeoffs

React-Draggable still works if we don't pass it the resizable ref, but React will log a big deprecation warning.


### Testing Done

All storybooks still worked and all tests passed.