### PR TITLE
Fix dragging and resizing on mobile

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -482,7 +482,7 @@ export class Rnd extends React.PureComponent<Props, State> {
     const top = -delta.height;
     const directions = ["top", "left", "topLeft", "bottomLeft", "topRight"];
 
-    if (directions.includes(direction)) {
+    if (directions.indexOf(direction) !== -1) {
       if (direction === "bottomLeft") {
         newPos.x += left;
       } else if (direction === "topRight") {


### PR DESCRIPTION
### Proposed solution
Fix for #725, `nodeRef` was preventing dragging on mobile. This PR also removes references to `nodeRef` that I forgot to remove last time in the type definition for the `<RND />` props and in the `render()` function.

**This PR also contains a fix to resizing on mobile that existed before we added `nodeRef`**.
When testing this on mobile, I noticed that resizing did not behave as expected. While resizing, the position of the box would also shift the position box around.

See #725 for more info on that bug and how this PR fixes it.

### Testing Done
I tested this in Chrome, Safari, Firefox, iOS Safari and Android Chrome. Dragging and resizing both worked in all of them, and all tests passed. 

