### PR TITLE
Update index.tsx

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -360,8 +360,11 @@ export class Rnd extends React.PureComponent<Props, State> {
 
   onDrag(e: RndDragEvent, data: DraggableData) {
     if (this.props.onDrag) {
-      const offset = this.offsetFromParent;
-      return this.props.onDrag(e, { ...data, x: data.x - offset.left, y: data.y - offset.top });
+      // const offset = this.offsetFromParent;
+      // return this.props.onDrag(e, { ...data, x: data.x - offset.left, y: data.y - offset.top });
+      const { left, top } = this.offsetFromParent;
+      return this.props.onDragStop(e, { ...data, x: data.x + left, y: data.y + top });
+      
     }
   }
 


### PR DESCRIPTION
There is a typo on the [onDrag method](https://github.com/bokuweb/react-rnd/blob/4b268c5e7195f35cf3b17876a143f2840ee63d16/src/index.tsx#L361) returns

`return this.props.onDrag(e, { ...data, x: data.x - offset.left, y: data.y - offset.top });`

I think it should be return the same result as the onDragStop
`return this.props.onDragStop(e, { ...data, x: data.x + left, y: data.y + top });`


