### PR TITLE
fix glitch when dragAxis is enabled and component is being resized

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -616,6 +616,7 @@ export class Rnd extends React.PureComponent<Props, State> {
     }
     // INFO: Make uncontorolled component when resizing to control position by setPostion.
     const pos = this.resizing ? undefined : draggablePosition;
+    const dragAxisOrUndefined = this.resizing ? "both" : dragAxis;
 
     return (
       <Draggable
@@ -627,7 +628,7 @@ export class Rnd extends React.PureComponent<Props, State> {
         onStart={this.onDragStart}
         onDrag={this.onDrag}
         onStop={this.onDragStop}
-        axis={dragAxis}
+        axis={dragAxisOrUndefined}
         disabled={disableDragging}
         grid={dragGrid}
         bounds={bounds ? this.state.bounds : undefined}

--- a/stories/dragAxis/dragAxis.tsx
+++ b/stories/dragAxis/dragAxis.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { Rnd } from "../../src";
+import { style } from "../styles";
+
+type State = {
+  x: number;
+  y: number;
+  width: number | string;
+  height: number | string;
+};
+
+export default class dragAxis extends React.Component<{}, State> {
+  constructor(props) {
+    super(props);
+    this.state = {
+      width: 100,
+      height: 100,
+      x: 0,
+      y: 0,
+    };
+  }
+
+  render() {
+    return (
+      <Rnd
+        style={style}
+        size={{ width: this.state.width, height: this.state.height }}
+        position={{ x: this.state.x, y: this.state.y }}
+        onDragStop={(e, d) => {
+          this.setState({ ...this.state, ...d });
+        }}
+        onResizeStop={(e, direction, ref, delta, position) => {
+          this.setState({
+            ...this.state,
+            width: ref.style.width,
+            height: ref.style.height,
+            ...position,
+          });
+        }}
+        dragAxis="x"
+      >
+        001
+      </Rnd>
+    );
+  }
+}

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -35,6 +35,8 @@ import Cancel from "./cancel/cancel";
 
 import ResizeHandleComponent from "./customization/resizeHandleComponent";
 
+import DragAxis from "./dragAxis/dragAxis";
+
 import GridResize from "./grid/resize";
 import GridDrag from "./grid/drag";
 import GridBoth from "./grid/both";
@@ -79,6 +81,8 @@ storiesOf("callbacks", module).add("callback", () => <Callbacks />);
 storiesOf("cancel", module).add("cancel", () => <Cancel />);
 
 storiesOf("customization", module).add("resizeHandleComponent", () => <ResizeHandleComponent />);
+
+storiesOf("dragAxis", module).add("dragAxis", () => <DragAxis />);
 
 storiesOf("grid", module)
   .add("resize", () => <GridResize />)


### PR DESCRIPTION

### Proposed solution
When `Rnd` has a `dragAxis` value other than `both`, resizing will cause the component to "jump".

To fix this, while component is being resized, set the `dragAxis` on `Draggable` to `both`. It shouldn't be dragged and resized at the same time so it will have no effect.

Here's a gif of the behavior with `dragAxis='x'` and the sandbox with the code to emulate it

![CPT2105182105-696x328](https://user-images.githubusercontent.com/8140475/118755490-cd213500-b81d-11eb-9bc6-29460101f333.gif)

[Codesandbox](https://codesandbox.io/s/musing-hamilton-k8zr9)

### Tradeoffs
A tradeoff is that if the component has to be dragged AND resized at the same time, then `Draggable` will move freely on both axis. I don't think this is the intended use though, and I don't see any negative effect.

### Testing Done
I have created a new story on the storybook titled `dragAxis`. I've tested the functionality here and tested some of the existing stories.


