### PR TITLE
Bound check locked aspect ratio (Fully fixes #209)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -436,7 +436,7 @@ export class Rnd extends React.PureComponent<Props, State> {
         const selfRect = self.getBoundingClientRect();
         const selfLeft = selfRect.left;
         const selfTop = selfRect.top;
-        const boundaryRect = this.props.bounds === "window" ? { left: 0, top: 0, bottom: 0 } : boundary.getBoundingClientRect();
+        const boundaryRect = this.props.bounds === "window" ? { left: 0, top: 0 } : boundary.getBoundingClientRect();
         const boundaryLeft = boundaryRect.left;
         const boundaryTop = boundaryRect.top;
         const offsetWidth = this.getOffsetWidth(boundary);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -439,7 +439,6 @@ export class Rnd extends React.PureComponent<Props, State> {
         const boundaryRect = this.props.bounds === "window" ? { left: 0, top: 0, bottom: 0 } : boundary.getBoundingClientRect();
         const boundaryLeft = boundaryRect.left;
         const boundaryTop = boundaryRect.top;
-        const boundaryBottom = boundaryRect.bottom;
         const offsetWidth = this.getOffsetWidth(boundary);
         const offsetHeight = this.getOffsetHeight(boundary);
         const hasLeft = dir.toLowerCase().endsWith("left");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -436,9 +436,10 @@ export class Rnd extends React.PureComponent<Props, State> {
         const selfRect = self.getBoundingClientRect();
         const selfLeft = selfRect.left;
         const selfTop = selfRect.top;
-        const boundaryRect = this.props.bounds === "window" ? { left: 0, top: 0 } : boundary.getBoundingClientRect();
+        const boundaryRect = this.props.bounds === "window" ? { left: 0, top: 0, bottom: 0 } : boundary.getBoundingClientRect();
         const boundaryLeft = boundaryRect.left;
         const boundaryTop = boundaryRect.top;
+        const boundaryBottom = boundaryRect.bottom;
         const offsetWidth = this.getOffsetWidth(boundary);
         const offsetHeight = this.getOffsetHeight(boundary);
         const hasLeft = dir.toLowerCase().endsWith("left");
@@ -455,14 +456,14 @@ export class Rnd extends React.PureComponent<Props, State> {
           const max = offsetWidth + (boundaryLeft - selfLeft) / scale;
           this.setState({ maxWidth: max > Number(maxWidth) ? maxWidth : max });
         }
-        if (hasTop && this.resizable) {
+        if ((hasTop || hasLeft) && this.resizable) {
           const max = (selfTop - boundaryTop) / scale + this.resizable.size.height;
           this.setState({
             maxHeight: max > Number(maxHeight) ? maxHeight : max,
           });
         }
         // INFO: To set bounds in `lock aspect ratio with bounds` case. See also that story.
-        if (hasBottom || (this.props.lockAspectRatio && !hasTop)) {
+        if (hasBottom || (this.props.lockAspectRatio && !hasTop && !hasLeft)) {
           const max = offsetHeight + (boundaryTop - selfTop) / scale;
           this.setState({
             maxHeight: max > Number(maxHeight) ? maxHeight : max,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -445,12 +445,13 @@ export class Rnd extends React.PureComponent<Props, State> {
         const hasRight = dir.toLowerCase().endsWith("right");
         const hasTop = dir.startsWith("top");
         const hasBottom = dir.startsWith("bottom");
-        if (hasLeft && this.resizable) {
+
+        if ((hasLeft || hasTop) && this.resizable) {
           const max = (selfLeft - boundaryLeft) / scale + this.resizable.size.width;
           this.setState({ maxWidth: max > Number(maxWidth) ? maxWidth : max });
         }
         // INFO: To set bounds in `lock aspect ratio with bounds` case. See also that story.
-        if (hasRight || (this.props.lockAspectRatio && !hasLeft)) {
+        if (hasRight || (this.props.lockAspectRatio && !hasLeft && !hasTop)) {
           const max = offsetWidth + (boundaryLeft - selfLeft) / scale;
           this.setState({ maxWidth: max > Number(maxWidth) ? maxWidth : max });
         }


### PR DESCRIPTION
### Proposed solution
This fixes the following issues reproducible under the [`sandbox/lock-aspect-ratio-with-bounds`](https://bokuweb.github.io/react-rnd/stories/?path=/story/sandbox--lock-aspect-ratio-with-bounds) storybook:

1. Position the draggable close to the left bound. Resizing it from the top will make it overflow the left bound.
2. Position it close the right bound. Resizing it from the top is limited by the right bound.
3. Same as 2: position close to bottom bound and resize from the left.

A directly related problem was fixed in #387 (issue #209), but these situations seem to have been overlooked.

### Tradeoffs
Not sure how relevant of an issue this is, but the bound checks are not super straight-forward to understand, and these changes might make this even worse.

### Testing Done
The other bound checks were tested manually and they seem to still be working as intended.


