### PR TITLE
fix: add missing peer dependencies `react` and `react-dom`

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,5 +102,9 @@
     "re-resizable": "6.9.5",
     "react-draggable": "4.4.4",
     "tslib": "2.3.1"
+  },
+  "peerDependencies": {
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
   }
 }


### PR DESCRIPTION
### Proposed solution

`react-rnd` tries to import from `react` but doesn't declare it as a dependency while `react-draggable` and `re-resizable` both have a peer dependency on `react-dom` but `react-rnd` doesn't provide it.
In order to resolve these dependency issues I added both as peer dependencies using the range from 

Fixes https://github.com/bokuweb/react-rnd/issues/771
Fixes https://github.com/yarnpkg/berry/issues/4371

### Tradeoffs

N/A

### Testing Done

N/A