### PR TITLE
fix: storybook wont start and causes in ModuleBuildError ('loose' mode configuration in babel)

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,11 @@
 module.exports = {
-  presets: ["@babel/preset-typescript", "@babel/preset-react"],
-  plugins: ["@babel/plugin-transform-modules-commonjs", "@babel/plugin-proposal-class-properties"],
+  presets: [
+    "@babel/preset-typescript",
+    '@babel/preset-env',
+    "@babel/preset-react"
+  ],
+  plugins: [
+    "@babel/plugin-transform-modules-commonjs",
+    ["@babel/plugin-proposal-class-properties", { "loose": true }]
+  ],
 };


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->
Storybook wont start, because of:

`ModuleBuildError: Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: /Users/alim/repos/react-rnd/storybook-init-framework-entry.js: 'loose' mode configuration must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled).
`
Solution:
Set loose mode true for babel/plugin-proposal-class-properties

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->
(unknown)

### Testing Done
<!-- How have you confirmed this feature works? -->
After changes, storybook runs again and works like expected. 

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


