### PR TITLE
fix: don't update based on parent offset on mount

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -239,12 +239,10 @@ export class Rnd extends React.PureComponent<Props, State> {
   }
 
   componentDidMount() {
-    this.updateOffsetFromParent();
-    const { left, top } = this.offsetFromParent;
     const { x, y } = this.getDraggablePosition();
     this.draggable.setState({
-      x: x - left,
-      y: y - top,
+      x,
+      y,
     });
     // HACK: Apply position adjustment
     this.forceUpdate();
@@ -363,11 +361,25 @@ export class Rnd extends React.PureComponent<Props, State> {
     if (!this.props.onDrag) return;
     const { left, top } = this.offsetFromParent;
     if (!this.props.dragAxis || this.props.dragAxis === "both") {
-      return this.props.onDrag(e, { ...data, x: data.x - left, y: data.y - top });
+      return this.props.onDrag(e, {
+        ...data,
+        x: data.x - left,
+        y: data.y - top,
+      });
     } else if (this.props.dragAxis === "x") {
-      return this.props.onDrag(e, { ...data, x: data.x + left, y: this.originalPosition.y + top, deltaY: 0 });
+      return this.props.onDrag(e, {
+        ...data,
+        x: data.x + left,
+        y: this.originalPosition.y + top,
+        deltaY: 0,
+      });
     } else if (this.props.dragAxis === "y") {
-      return this.props.onDrag(e, { ...data, x: this.originalPosition.x + left, y: data.y + top, deltaX: 0 });
+      return this.props.onDrag(e, {
+        ...data,
+        x: this.originalPosition.x + left,
+        y: data.y + top,
+        deltaX: 0,
+      });
     }
   }
 
@@ -375,11 +387,25 @@ export class Rnd extends React.PureComponent<Props, State> {
     if (!this.props.onDragStop) return;
     const { left, top } = this.offsetFromParent;
     if (!this.props.dragAxis || this.props.dragAxis === "both") {
-      return this.props.onDragStop(e, { ...data, x: data.x + left, y: data.y + top });
+      return this.props.onDragStop(e, {
+        ...data,
+        x: data.x + left,
+        y: data.y + top,
+      });
     } else if (this.props.dragAxis === "x") {
-      return this.props.onDragStop(e, { ...data, x: data.x + left, y: this.originalPosition.y + top, deltaY: 0 });
+      return this.props.onDragStop(e, {
+        ...data,
+        x: data.x + left,
+        y: this.originalPosition.y + top,
+        deltaY: 0,
+      });
     } else if (this.props.dragAxis === "y") {
-      return this.props.onDragStop(e, { ...data, x: this.originalPosition.x + left, y: data.y + top, deltaX: 0 });
+      return this.props.onDragStop(e, {
+        ...data,
+        x: this.originalPosition.x + left,
+        y: data.y + top,
+        deltaX: 0,
+      });
     }
   }
 
@@ -635,6 +661,8 @@ export class Rnd extends React.PureComponent<Props, State> {
     // INFO: Make uncontorolled component when resizing to control position by setPostion.
     const pos = this.state.resizing ? undefined : draggablePosition;
     const dragAxisOrUndefined = this.state.resizing ? "both" : dragAxis;
+
+    console.log(defaultValue, pos);
 
     return (
       <Draggable


### PR DESCRIPTION
* I'm not sure if this will work for all use cases, but for me it is workig much better, before this fix there was an issue when the component position was stored externally and the component is remounted with a defaultPos - it will jump by the parent offset pixels, which just isn't right. In my eyes it should just use the exact position passed to it from consumers as the starting position, if a consumer wants to use the absolute value they can pass that, otherwise the position they use `lastX` `lastY` for example is relative to the parent anyway. So whats the point of applying this offset to those values?

<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
<!-- Which specific problem does this PR solve and how?  -->
<!-- If it fixes a particular Issue, add "Fixes #ISSUE_NUMBER" in your title -->

### Tradeoffs
<!-- What are the drawbacks of this solution? Are there alternative ones? -->
<!-- Think of performance, build time, usability, complexity, coupling…) -->


### Testing Done
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


