### PR TITLE
feat: adding ability to use a separate bounding box for resizing and dragging (Fixes #895)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -130,6 +130,7 @@ export interface Props {
   size?: Size;
   resizeGrid?: Grid;
   bounds?: string | Element;
+  resizeBounds?: string | Element;
   onMouseDown?: (e: MouseEvent) => void;
   onMouseUp?: (e: MouseEvent) => void;
   onResizeStart?: RndResizeStartCallback;
@@ -398,19 +399,19 @@ export class Rnd extends React.PureComponent<Props, State> {
     this.resizingPosition = { x: pos.x + offset.left, y: pos.y + offset.top };
     this.originalPosition = pos;
 
-    if (this.props.bounds) {
+    if ((this.props.resizeBounds || this.props.bounds)) {
       const parent = this.getParent();
       let boundary;
-      if (this.props.bounds === "parent") {
+      if ((this.props.resizeBounds || this.props.bounds) === "parent") {
         boundary = parent;
-      } else if (this.props.bounds === "body") {
+      } else if ((this.props.resizeBounds || this.props.bounds) === "body") {
         boundary = document.body;
-      } else if (this.props.bounds === "window") {
+      } else if ((this.props.resizeBounds || this.props.bounds) === "window") {
         boundary = window;
-      } else if (typeof this.props.bounds === "string") {
-        boundary = document.querySelector(this.props.bounds);
-      } else if (this.props.bounds instanceof HTMLElement) {
-        boundary = this.props.bounds;
+      } else if (typeof (this.props.resizeBounds || this.props.bounds) === "string") {
+        boundary = document.querySelector((this.props.resizeBounds || this.props.bounds));
+      } else if ((this.props.resizeBounds || this.props.bounds) instanceof HTMLElement) {
+        boundary = (this.props.resizeBounds || this.props.bounds);
       }
 
       const self = this.getSelfElement();
@@ -440,7 +441,7 @@ export class Rnd extends React.PureComponent<Props, State> {
         const selfRect = self.getBoundingClientRect();
         const selfLeft = selfRect.left;
         const selfTop = selfRect.top;
-        const boundaryRect = this.props.bounds === "window" ? { left: 0, top: 0 } : boundary.getBoundingClientRect();
+        const boundaryRect = (this.props.resizeBounds || this.props.bounds) === "window" ? { left: 0, top: 0 } : boundary.getBoundingClientRect();
         const boundaryLeft = boundaryRect.left;
         const boundaryTop = boundaryRect.top;
         const offsetWidth = this.getOffsetWidth(boundary);
@@ -617,6 +618,7 @@ export class Rnd extends React.PureComponent<Props, State> {
     const defaultValue = this.props.default ? { ...this.props.default } : undefined;
     // Remove unknown props, see also https://reactjs.org/warnings/unknown-prop.html
     delete resizableProps.default;
+    delete resizableProps.resizeBounds;
 
     const cursorStyle = disableDragging || dragHandleClassName ? { cursor: "auto" } : { cursor: "move" };
     const innerStyle = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
+import { Enable, Resizable, ResizeDirection } from "re-resizable";
 import * as React from "react";
 import { DraggableEventHandler, default as DraggableRoot } from "react-draggable";
-import { Enable, Resizable, ResizeDirection } from "re-resizable";
 
 // FIXME: https://github.com/mzabriskie/react-draggable/issues/381
 //         I can not find `scale` too...
@@ -402,16 +402,17 @@ export class Rnd extends React.PureComponent<Props, State> {
     if ((this.props.resizeBounds || this.props.bounds)) {
       const parent = this.getParent();
       let boundary;
-      if ((this.props.resizeBounds || this.props.bounds) === "parent") {
+      const boundaryBeingUsed = this.props.resizeBounds || this.props.bounds;
+      if (boundaryBeingUsed === "parent") {
         boundary = parent;
-      } else if ((this.props.resizeBounds || this.props.bounds) === "body") {
+      } else if (boundaryBeingUsed === "body") {
         boundary = document.body;
-      } else if ((this.props.resizeBounds || this.props.bounds) === "window") {
+      } else if (boundaryBeingUsed === "window") {
         boundary = window;
-      } else if (typeof (this.props.resizeBounds || this.props.bounds) === "string") {
-        boundary = document.querySelector((this.props.resizeBounds || this.props.bounds));
-      } else if ((this.props.resizeBounds || this.props.bounds) instanceof HTMLElement) {
-        boundary = (this.props.resizeBounds || this.props.bounds);
+      } else if (typeof boundaryBeingUsed === "string") {
+        boundary = document.querySelector(boundaryBeingUsed);
+      } else if (boundaryBeingUsed instanceof HTMLElement) {
+        boundary = boundaryBeingUsed;
       }
 
       const self = this.getSelfElement();


### PR DESCRIPTION
This patch has been running in production for us for over a year and works well. It allows the resize and drag boundarys to be different. I thought I would convert the patch into a PR to share with others

I was unable to run the tests locally so couldn't add anymore - there's an error when running 

```
.../react-rnd/node_modules/electron/dist/electron: error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory
```

but this is the work required