### PR TITLE
Define callback refs inline to work with latest versions of Next.js / React

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -568,17 +568,6 @@ export class Rnd extends React.PureComponent<Props, State> {
     };
   }
 
-  refDraggable = (c: Draggable) => {
-    if (!c) return;
-    this.draggable = c;
-  };
-
-  refResizable = (c: Resizable | null) => {
-    if (!c) return;
-    this.resizable = c;
-    this.resizableElement.current = c.resizable;
-  };
-
   render() {
     const {
       disableDragging,
@@ -634,7 +623,10 @@ export class Rnd extends React.PureComponent<Props, State> {
 
     return (
       <Draggable
-        ref={this.refDraggable}
+        ref={(c: Draggable) => {
+          if (!c) return;
+          this.draggable = c;
+        }}
         handle={dragHandleClassName ? `.${dragHandleClassName}` : undefined}
         defaultPosition={defaultValue}
         onMouseDown={onMouseDown}
@@ -656,7 +648,11 @@ export class Rnd extends React.PureComponent<Props, State> {
       >
         <Resizable
           {...resizableProps}
-          ref={this.refResizable}
+          ref={(c: Resizable | null) => {
+            if (!c) return;
+            this.resizable = c;
+            this.resizableElement.current = c.resizable;
+          }}
           defaultSize={defaultValue}
           size={this.props.size}
           enable={typeof enableResizing === "boolean" ? getEnableResizingByFlag(enableResizing) : enableResizing}


### PR DESCRIPTION
Callback refs defined as class functions don't get invoked in Next.js 14.2+ – and therefore don't work – perhaps because of changes to the underlying React which is at or near version 19.

This should fix https://github.com/bokuweb/react-rnd/issues/941 along with the related PR on re-resizable: https://github.com/bokuweb/re-resizable/pull/819

Tested and confirmed to work with the latest stable version of Next.js 14.2.3