### PR TITLE
Symmetrical resize feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,11 @@ you to, for example, get the correct resize and drag deltas while you are zoomed
 a transform or matrix in the parent of this element.
 If omitted, set `1`.
 
+#### `resizeSymmetry?: 'none' | 'vertical' | 'horizontal' | 'central'`
+
+Allows resize so what `vertical` or `horizontal` axes or `central` point stands still while resizing. 
+Also useful with `lockAspectRatio` option.
+
 ## Callback
 
 #### `onResizeStart?: RndResizeStartCallback;`

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -447,28 +447,56 @@ export class Rnd extends React.PureComponent<Props, State> {
         const hasTop = dir.startsWith("top");
         const hasBottom = dir.startsWith("bottom");
 
-        if ((hasLeft || hasTop) && this.resizable) {
-          const max = (selfLeft - boundaryLeft) / scale + this.resizable.size.width;
-          this.setState({ maxWidth: max > Number(maxWidth) ? maxWidth : max });
+        if (!this.props.resizeSymmetry || this.props.resizeSymmetry == "none")
+        {
+          if ((hasLeft || hasTop) && this.resizable) {
+            const max = (selfLeft - boundaryLeft) / scale + this.resizable.size.width;
+            this.setState({ maxWidth: max > Number(maxWidth) ? maxWidth : max });
+          }
+          // INFO: To set bounds in `lock aspect ratio with bounds` case. See also that story.
+          if (hasRight || (this.props.lockAspectRatio && !hasLeft && !hasTop)) {
+            const max = offsetWidth  + (boundaryLeft - selfLeft) / scale;
+            this.setState({ maxWidth: max > Number(maxWidth) ? maxWidth : max });
+          }
+          if ((hasTop || hasLeft) && this.resizable) {
+            const max = (selfTop - boundaryTop) / scale + this.resizable.size.height;
+            this.setState({
+              maxHeight: max > Number(maxHeight) ? maxHeight : max,
+            });
+          }
+          // INFO: To set bounds in `lock aspect ratio with bounds` case. See also that story.
+          if (hasBottom || (this.props.lockAspectRatio && !hasTop && !hasLeft)) {
+            const max = offsetHeight + (boundaryTop - selfTop) / scale;
+            this.setState({
+              maxHeight: max > Number(maxHeight) ? maxHeight : max,
+            });
+          }
         }
-        // INFO: To set bounds in `lock aspect ratio with bounds` case. See also that story.
-        if (hasRight || (this.props.lockAspectRatio && !hasLeft && !hasTop)) {
-          const max = offsetWidth + (boundaryLeft - selfLeft) / scale;
-          this.setState({ maxWidth: max > Number(maxWidth) ? maxWidth : max });
-        }
-        if ((hasTop || hasLeft) && this.resizable) {
-          const max = (selfTop - boundaryTop) / scale + this.resizable.size.height;
-          this.setState({
-            maxHeight: max > Number(maxHeight) ? maxHeight : max,
-          });
-        }
-        // INFO: To set bounds in `lock aspect ratio with bounds` case. See also that story.
-        if (hasBottom || (this.props.lockAspectRatio && !hasTop && !hasLeft)) {
-          const max = offsetHeight + (boundaryTop - selfTop) / scale;
-          this.setState({
-            maxHeight: max > Number(maxHeight) ? maxHeight : max,
-          });
-        }
+        else
+        {
+          if ((hasLeft || hasTop || hasRight || (this.props.lockAspectRatio && !hasLeft && !hasTop)) && this.resizable) {
+            if (this.props.resizeSymmetry == "vertical" || this.props.resizeSymmetry == "central")
+            {
+              const spaceLeft = (selfLeft - boundaryLeft) / scale;
+              const spaceRight = offsetWidth - spaceLeft - this.resizable.size.width;
+              const max = spaceRight > spaceLeft ? (this.resizable.size.width + 2 * spaceLeft) : (this.resizable.size.width + 2 * spaceRight);
+              this.setState({ maxWidth: max > Number(maxWidth) ? maxWidth : max });
+            }                          
+          }
+
+          if ((hasTop || hasLeft || hasBottom || (this.props.lockAspectRatio && !hasTop && !hasLeft)) && this.resizable) {            
+            if (this.props.resizeSymmetry == "horizontal" || this.props.resizeSymmetry == "central")
+            {
+              const spaceTop = (selfTop - boundaryTop) / scale;
+              const spaceBottom = offsetHeight - spaceTop - this.resizable.size.height;
+              const max = spaceBottom > spaceTop ? (this.resizable.size.height + 2 * spaceTop) : (this.resizable.size.height + 2 * spaceBottom);
+
+              this.setState({
+                maxHeight: max > Number(maxHeight) ? maxHeight : max,
+              });
+            }
+          }
+        }        
       }
     } else {
       this.setState({
@@ -505,7 +533,7 @@ export class Rnd extends React.PureComponent<Props, State> {
         }
       }
     }
-    else if (!this.props.resizeSymmetry || this.props.resizeSymmetry == "vertical")
+    else if (this.props.resizeSymmetry == "vertical")
     {
       const left = -delta.width / 2;
       const top = -delta.height;
@@ -522,7 +550,7 @@ export class Rnd extends React.PureComponent<Props, State> {
         }
       }
     }
-    else if (!this.props.resizeSymmetry || this.props.resizeSymmetry == "horizontal")
+    else if (this.props.resizeSymmetry == "horizontal")
     {
       const left = -delta.width;
       const top = -delta.height / 2;
@@ -536,7 +564,7 @@ export class Rnd extends React.PureComponent<Props, State> {
         }
       }
     }
-    else if (!this.props.resizeSymmetry || this.props.resizeSymmetry == "central")
+    else if (this.props.resizeSymmetry == "central")
     {
       const left = -delta.width / 2;
       const top = -delta.height / 2;

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -51,6 +51,10 @@ import SandboxLockAspectRatioWithBounds from "./sandbox/lock-aspect-ratio-with-b
 import LockAspectRatioBasic from "./lock-aspect-ratio/basic";
 import Issue622 from "./sandbox/issue-#622";
 
+import ResizeSymmetryVertical from "./resizeSymmetry/vertical"
+import ResizeSymmetryHorizontal from "./resizeSymmetry/horizontal"
+import ResizeSymmetryCentral from "./resizeSymmetry/central"
+
 storiesOf("bare", module).add("bare", () => <Bare />);
 
 storiesOf("basic", module)
@@ -106,3 +110,8 @@ storiesOf("sandbox", module)
 storiesOf("ratio", module).add("lock aspect ratio", () => <LockAspectRatioBasic />);
 
 storiesOf("min", module).add("min uncontrolled", () => <MinUncontrolled />);
+
+storiesOf("resize symmetry", module).add("vertical", () => <ResizeSymmetryVertical />);
+storiesOf("resize symmetry", module).add("horizontal", () => <ResizeSymmetryHorizontal />);
+storiesOf("resize symmetry", module).add("central", () => <ResizeSymmetryCentral />);
+

--- a/stories/index.tsx
+++ b/stories/index.tsx
@@ -54,6 +54,7 @@ import Issue622 from "./sandbox/issue-#622";
 import ResizeSymmetryVertical from "./resizeSymmetry/vertical"
 import ResizeSymmetryHorizontal from "./resizeSymmetry/horizontal"
 import ResizeSymmetryCentral from "./resizeSymmetry/central"
+import ResizeSymmetryBounds from "./resizeSymmetry/bounds"
 
 storiesOf("bare", module).add("bare", () => <Bare />);
 
@@ -114,4 +115,5 @@ storiesOf("min", module).add("min uncontrolled", () => <MinUncontrolled />);
 storiesOf("resize symmetry", module).add("vertical", () => <ResizeSymmetryVertical />);
 storiesOf("resize symmetry", module).add("horizontal", () => <ResizeSymmetryHorizontal />);
 storiesOf("resize symmetry", module).add("central", () => <ResizeSymmetryCentral />);
+storiesOf("resize symmetry", module).add("bounds", () => <ResizeSymmetryBounds />);
 

--- a/stories/resizeSymmetry/bounds.tsx
+++ b/stories/resizeSymmetry/bounds.tsx
@@ -1,0 +1,39 @@
+import React, {CSSProperties} from "react";
+import { Rnd } from "../../src";
+import { style, parentBoundary } from "../styles";
+
+const innerDiv: CSSProperties = {
+  display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    border: "dashed 1px #9C27B0",
+    height: "120%",
+};
+const lineStyle: CSSProperties = {
+  width: "120%",
+  top: "50%",
+  border: "dashed 1px #9C27B0",
+  position: 'absolute'
+}
+
+
+export default () => (
+  <div style={parentBoundary}>
+  <Rnd
+    style={style}
+    bounds="parent"
+    default={{
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+    }}
+    resizeSymmetry="central"
+  >
+    <div style={lineStyle} />
+    <div style={innerDiv}>
+    
+    </div>
+  </Rnd>
+  </div>
+);

--- a/stories/resizeSymmetry/central.tsx
+++ b/stories/resizeSymmetry/central.tsx
@@ -1,0 +1,36 @@
+import React, {CSSProperties} from "react";
+import { Rnd } from "../../src";
+import { style } from "../styles";
+
+const innerDiv: CSSProperties = {
+  display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    border: "dashed 1px #9C27B0",
+    height: "120%",
+};
+const lineStyle: CSSProperties = {
+  width: "120%",
+  top: "50%",
+  border: "dashed 1px #9C27B0",
+  position: 'absolute'
+}
+
+
+export default () => (
+  <Rnd
+    style={style}
+    default={{
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+    }}
+    resizeSymmetry="central"
+  >
+    <div style={lineStyle} />
+    <div style={innerDiv}>
+    
+    </div>
+  </Rnd>
+);

--- a/stories/resizeSymmetry/horizontal.tsx
+++ b/stories/resizeSymmetry/horizontal.tsx
@@ -1,0 +1,25 @@
+import React, {CSSProperties} from "react";
+import { Rnd } from "../../src";
+import { style } from "../styles";
+
+const lineStyle: CSSProperties = {
+  width: "120%",
+  top: "50%",
+  border: "dashed 1px #9C27B0",
+  position: 'absolute'
+}
+
+export default () => (
+  <Rnd
+    style={style}
+    default={{
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+    }}
+    resizeSymmetry="horizontal"
+  >
+    <div style={lineStyle} />
+  </Rnd>
+);

--- a/stories/resizeSymmetry/vertical.tsx
+++ b/stories/resizeSymmetry/vertical.tsx
@@ -1,0 +1,28 @@
+import React, {CSSProperties} from "react";
+import { Rnd } from "../../src";
+import { style } from "../styles";
+
+const innerDiv: CSSProperties = {
+  display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    border: "dashed 1px #9C27B0",
+    height: "120%",
+};
+
+export default () => (
+  <Rnd
+    style={style}
+    default={{
+      width: 200,
+      height: 200,
+      x: 0,
+      y: 0,
+    }}
+    resizeSymmetry="vertical"
+  >
+    <div style={innerDiv}>
+      
+    </div>
+  </Rnd>
+);


### PR DESCRIPTION
Added property:

#### `resizeSymmetry?: 'none' | 'vertical' | 'horizontal' | 'central'`

Allows resize so what `vertical` or `horizontal` axes or `central` point stands still while resizing. 
Also useful with `lockAspectRatio` option.

`vertical`:
![hippo](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMGh0M2h3dXRrM2YzdGhqdjNpYnZmbzZyNjYxenJ5MGQ1aDNkbHo3YSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UIEjSBXbm5rzrKbVCj/giphy.gif)

`horizontal`:
![hippo](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExanRleXVweTdhb2xtd3F5cjluNzJoZHduaXJkM2dzN3Y0d3FmZ3VqcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BmU3RBy1LDxYCzVuWD/giphy.gif)

`central`:
![hippo](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXozdjlzZnkxcDd6N3gxdDB0MWFnbjJvOXNqMWVqaHRteWRhdGdycCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/cRir5F5gwfPIFIMp80/giphy.gif)

Also fix 
https://github.com/bokuweb/react-rnd/issues/740

### Testing Done
See stories under Resize Symmetry section

