### PR TITLE
Bump re-resizable@6.10.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "fixture": "./fixture.html"
   },
   "dependencies": {
-    "re-resizable": "6.10.0",
+    "re-resizable": "6.10.3",
     "react-draggable": "4.4.6",
     "tslib": "2.6.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       re-resizable:
-        specifier: 6.10.0
-        version: 6.10.0(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+        specifier: 6.10.3
+        version: 6.10.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       react-draggable:
         specifier: 4.4.6
         version: 4.4.6(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
@@ -5006,11 +5006,11 @@ packages:
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
 
-  re-resizable@6.10.0:
-    resolution: {integrity: sha512-hysSK0xmA5nz24HBVztlk4yCqCLCvS32E6ZpWxVKop9x3tqCa4yAj1++facrmkOf62JsJHjmjABdKxXofYioCw==}
+  re-resizable@6.10.3:
+    resolution: {integrity: sha512-zvWb7X3RJMA4cuSrqoxgs3KR+D+pEXnGrD2FAD6BMYAULnZsSF4b7AOVyG6pC3VVNVOtlagGDCDmZSwWLjjBBw==}
     peerDependencies:
-      react: ^16.13.1 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0
+      react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-addons-create-fragment@15.6.2:
     resolution: {integrity: sha512-O9+cXwMGcMF7WfpZHw+Lt8+jkRhyQBgihOVz9xfGMRORMdMf40HLeQQbdwPUQB7G73+/Zc+hB77A/UyE58n9Og==}
@@ -12736,7 +12736,7 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 4.47.0
 
-  re-resizable@6.10.0(react-dom@16.14.0(react@16.14.0))(react@16.14.0):
+  re-resizable@6.10.3(react-dom@16.14.0(react@16.14.0))(react@16.14.0):
     dependencies:
       react: 16.14.0
       react-dom: 16.14.0(react@16.14.0)


### PR DESCRIPTION
<!-- PLEASE READ THE FOLLOWING INSTRUCTIONS -->
<!-- DO NOT REBUILD THE CSS OUTPUT IN YOUR PR -->

### Proposed solution
When installing `react-rnd` using `Yarn`, I got warnings like below

```
➤ YN0060: │ react is listed by your project with version 19.0.0 (p0f89c), which doesn't satisfy what re-resizable (via @finos/legend-art) and other dependencies request (but they have non-overlapping ranges!).
```

This is due to `react-rnd` depends on an older version of `re-resizable` that hasn't include `react@v19` as peerDependency. So I would like to do this bump since I saw your change in `re-resizable@6.10.3`.

@bokuweb Please let me know if you need anymore context, but if you could take this change, that would be great!

### Tradeoffs
I'm not fully aware of the internals of `re-resizable` nor `react-rnd`, really naive about this change.


### Testing Done
<!-- How have you confirmed this feature works? -->

<!-- BEFORE SUBMITTING YOUR PR, MAKE SURE TO FOLLOW THESE STEPS: -->
<!-- 1. Pull the latest `master` branch -->
<!-- 4. If your PR fixes an issue, reference that issue -->


